### PR TITLE
Added numpy, pandas, xarray to intersphinx mapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,9 +94,10 @@ html_sidebars = {
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
                        # Commonly used libraries, uncomment when used in package
-                       # 'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+                       'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+                       'pandas': ('http://pandas.pydata.org/docs/', None),
+                       'xarray': ('https://docs.xarray.dev/en/stable/', None),
                        # 'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
                        # 'scikit-learn': ('https://scikit-learn.org/stable/', None),
                        # 'matplotlib': ('https://matplotlib.org/stable/', None),
-                       # 'pandas': ('http://pandas.pydata.org/docs/', None),
                        }


### PR DESCRIPTION
For integration in the docs, the numpy pandas and xarray documentation links have been added to the intersphinx mapping