### PR TITLE
Avoid locale issues in generating forcing .mat files

### DIFF
--- a/PyStemmusScope/forcing_io.py
+++ b/PyStemmusScope/forcing_io.py
@@ -161,7 +161,7 @@ def prepare_global_variables(data, input_path, config):
     matfiledata['Dur_tot'] = float(total_duration) # Matlab expects a 'double'
 
     hdf5storage.savemat(input_path / "forcing_globals.mat", matfiledata, appendmat=False)
-    utils.sanitize_mat_file(input_path / "forcing_globals.mat")
+    utils.remove_dates_from_header(input_path / "forcing_globals.mat")
 
 
 def prepare_forcing(config):

--- a/PyStemmusScope/forcing_io.py
+++ b/PyStemmusScope/forcing_io.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import hdf5storage
 import numpy as np
 import xarray as xr
+from . import utils
 from . import variable_conversion as vc
 
 
@@ -159,7 +160,8 @@ def prepare_global_variables(data, input_path, config):
 
     matfiledata['Dur_tot'] = float(total_duration) # Matlab expects a 'double'
 
-    hdf5storage.savemat(input_path / 'forcing_globals.mat', matfiledata, appendmat=False)
+    hdf5storage.savemat(input_path / "forcing_globals.mat", matfiledata, appendmat=False)
+    utils.sanitize_mat_file(input_path / "forcing_globals.mat")
 
 
 def prepare_forcing(config):

--- a/PyStemmusScope/soil_io.py
+++ b/PyStemmusScope/soil_io.py
@@ -227,4 +227,4 @@ def prepare_soil_data(config):
     hdf5storage.savemat(
         Path(config["InputPath"]) / "soil_parameters.mat", mdict=matfiledata, appendmat=False,
     )
-    utils.sanitize_mat_file(Path(config["InputPath"]) / "soil_parameters.mat")
+    utils.remove_dates_from_header(Path(config["InputPath"]) / "soil_parameters.mat")

--- a/PyStemmusScope/soil_io.py
+++ b/PyStemmusScope/soil_io.py
@@ -227,3 +227,4 @@ def prepare_soil_data(config):
     hdf5storage.savemat(
         Path(config["InputPath"]) / "soil_parameters.mat", mdict=matfiledata, appendmat=False,
     )
+    utils.sanitize_mat_file(Path(config["InputPath"]) / "soil_parameters.mat")

--- a/PyStemmusScope/utils.py
+++ b/PyStemmusScope/utils.py
@@ -67,3 +67,23 @@ def to_absolute_path(
         must_exist = os_name() == 'nt'
 
     return pathlike.expanduser().resolve(strict=must_exist)
+
+
+def sanitize_mat_file(filename):
+    with open(filename, "rb") as f:
+        data = f.read()
+
+    # Get locations of date string in header
+    start_datestring = data[:128].find(b"Created on:") + 12
+    end_datestring = data[:128].find(b"HDF5") - 1
+
+    # Rebuild the data, with the dates in the header removed
+    sanitized_data = (
+        data[:start_datestring] +
+        b' '*len(data[start_datestring:end_datestring]) +
+        data[end_datestring:]
+        )
+
+    # Overwrite the old file
+    with open(filename, 'wb') as file:
+        file.write(sanitized_data)

--- a/PyStemmusScope/utils.py
+++ b/PyStemmusScope/utils.py
@@ -69,7 +69,15 @@ def to_absolute_path(
     return pathlike.expanduser().resolve(strict=must_exist)
 
 
-def sanitize_mat_file(filename):
+def remove_dates_from_header(filename):
+    """Removes the datetime string from the .mat file header.
+
+    MATLAB raises an error when some characters are non-UTF-8 (?), e.g. Chinese month
+    names. This function removes this part of the file header to avoid this problem.
+
+    Args:
+        filename (Path): Valid path to the .mat file
+    """
     with open(filename, "rb") as f:
         data = f.read()
 


### PR DESCRIPTION
This PR tackles issue #38. The problem is circumvented by removing the date string entirely and making it blank.

Note: PR includes commits of #45, to avoid merge conflicts and to have the Windows tests work.

[Discussion of this "bug" on hdf5storage.](https://github.com/frejanordsiek/hdf5storage/issues/123)

<hr>

Tested on:
- [x] Windows
- [x] Linux
- [x] Octave
- [x] MATLAB
