### PR TITLE
Pin Python<3.11 in conda's `environment.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.8', '3.9']
+        python-version: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - python>=3.8
+  - python>=3.8, <3.11
   - jupyterlab # needed to run notebooks
   - pip:
       - git+https://github.com/EcoExtreML/STEMMUS_SCOPE_Processing.git@main # will be replaced by `pip install pystemmusscope`

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = True
 packages = find:
 install_requires =
     hdf5storage
-    netcdf4
+    netcdf4<=1.5.8
     numpy
     pandas
     xarray

--- a/tests/test_stemmus_scope.py
+++ b/tests/test_stemmus_scope.py
@@ -14,15 +14,23 @@ class TestInit:
     def test_model_without_exe(self, tmp_path):
         config_file = str(data_folder / "config_file_test.txt")
         exe_file = Path(tmp_path) / "STEMMUS_SCOPE"
-        with pytest.raises(ValueError) as excinfo:
-            StemmusScope(config_file, model_src_path=exe_file)
-        assert "Provide a valid path to an executable file" in str(excinfo.value)
+        if utils.os_name() == 'nt':
+            with pytest.raises(FileNotFoundError):
+                StemmusScope(config_file, model_src_path=exe_file)
+        else:
+            with pytest.raises(ValueError) as excinfo:
+                StemmusScope(config_file, model_src_path=exe_file)
+            assert "Provide a valid path to an executable file" in str(excinfo.value)
 
     def test_model_without_src(self):
         config_file = str(data_folder / "config_file_test.txt")
-        with pytest.raises(ValueError) as excinfo:
-            StemmusScope(config_file, model_src_path="src")
-        assert "Provide a valid path to an executable file" in str(excinfo.value)
+        if utils.os_name() == 'nt':
+            with pytest.raises(FileNotFoundError):
+                StemmusScope(config_file, model_src_path="src")
+        else:
+            with pytest.raises(ValueError) as excinfo:
+                StemmusScope(config_file, model_src_path="src")
+            assert "Provide a valid path to an executable file" in str(excinfo.value)
 
     def test_model_without_interpreter(self, tmp_path):
         config_file = str(data_folder / "config_file_test.txt")


### PR DESCRIPTION
Closes #47 

Python versions 3.8, 3.9 and 3.10 are now valid. 3.11 is too new still (dependencies have to update first).

Tested on Windows, conda env creation went fine, and PyStemmusScope was importable.

Note: PR includes commits of #45.