### PR TITLE
Fixed conda env to py<3.11. Added Python 3.10 to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.8', '3.9']
+        python-version: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - python>=3.8
+  - python>=3.8, python<3.11
   - jupyterlab # needed to run notebooks
   - pip:
       - git+https://github.com/EcoExtreML/STEMMUS_SCOPE_Processing.git@main # will be replaced by `pip install pystemmusscope`

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,3 +10,4 @@ sonar.links.ci=https://github.com/EcoExtreML/stemmus_scope_processing/actions
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.xunit.reportPath=xunit-result.xml
 sonar.python.pylint.reportPaths=pylint-report.txt
+sonar.python.version=3.8, 3.9, 3.10


### PR DESCRIPTION
Closes https://github.com/EcoExtreML/STEMMUS_SCOPE_Processing/issues/47

Python versions 3.8, 3.9 and 3.10 are now valid. 3.11 is too new still (dependencies have to update first).

Tested on Windows, conda env creation went fine, and PyStemmusScope was importable.

(PR reopened from #49 due to a messy commit history...)

Additionally, I set Sonarcloud's python versions to this same range. No python version was set yet, causing Sonarcloud to give a warning.