### PR TITLE
Add a pypi badge

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 
 [comment]
 comment = The contents of this file cannot be merged with that of setup.cfg until https://github.com/c4urself/bump2version/issues/185 is resolved

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,10 @@
 version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
 python:
   install:
     - method: pip

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
     orcid: "https://orcid.org/0000-0000-0000-0000"
 date-released: 20??-MM-DD
 doi: <insert your DOI here>
-version: "0.1.0"
+version: "0.1.1"
 repository-code: "https://github.com/EcoExtreML/stemmus_scope_processing"
 keywords:
   - STEMMUS SCOPE Processing

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,10 +4,21 @@ cff-version: "1.1.0"
 title: "PyStemmusScope"
 authors:
   -
+    affiliation: "Netherlands eScience Center"
     family-names: Alidoost
     given-names: Sarah
     orcid: "https://orcid.org/0000-0000-0000-0000"
-date-released: 20??-MM-DD
+  -
+    affiliation: "Netherlands eScience Center"
+    family-names: Schilperoort
+    given-names: Bart
+    orcid: "https://orcid.org/0000-0003-4487-9822"
+  -
+    affiliation: "Netherlands eScience Center"
+    family-names: Liu
+    given-names: Yang
+    orcid: "https://orcid.org/0000-0002-1966-8460"
+date-released: 2022-11-24
 doi: <insert your DOI here>
 version: "0.1.1"
 repository-code: "https://github.com/EcoExtreML/stemmus_scope_processing"

--- a/PyStemmusScope/__init__.py
+++ b/PyStemmusScope/__init__.py
@@ -7,4 +7,4 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __author__ = "Sarah Alidoost"
 __email__ = "f.alidoost@esciencecenter.nl"
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 
 
 [![github repo badge](https://img.shields.io/badge/github-repo-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/EcoExtreML/stemmus_scope_processing)
+[![PyPI version](https://badge.fury.io/py/PyStemmusScope.svg)](https://badge.fury.io/py/PyStemmusScope)
 [![build](https://github.com/EcoExtreML/stemmus_scope_processing/actions/workflows/build.yml/badge.svg)](https://github.com/EcoExtreML/stemmus_scope_processing/actions/workflows/build.yml)
+[![Documentation Status](https://readthedocs.org/projects/pystemmusscope/badge/?version=latest)](https://pystemmusscope.readthedocs.io/en/latest/?badge=latest)
 [![fair-software badge](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B-yellow)](https://fair-software.eu)
 [![sonarcloud](https://github.com/EcoExtreML/stemmus_scope_processing/actions/workflows/sonarcloud.yml/badge.svg)](https://github.com/EcoExtreML/stemmus_scope_processing/actions/workflows/sonarcloud.yml)
 [![github license badge](https://img.shields.io/github/license/EcoExtreML/stemmus_scope_processing)](https://github.com/EcoExtreML/stemmus_scope_processing)
-[![Documentation Status](https://readthedocs.org/projects/pystemmusscope/badge/?version=latest)](https://pystemmusscope.readthedocs.io/en/latest/?badge=latest)
 
 <!-- [![RSD](https://img.shields.io/badge/rsd-pystemmusscope-00a3e3.svg)](https://www.research-software.nl/software/pystemmusscope)
 [![workflow pypi badge](https://img.shields.io/pypi/v/pystemmusscope.svg?colorB=blue)](https://pypi.python.org/project/pystemmusscope/)
@@ -60,7 +61,7 @@ conda environment before submitting the the bash script. See
 ### On CRIB
 
 [CRIB](https://crib.utwente.nl/) is the ITC Geospatial Computing Platform. You
-can run the model using `Matlab` or `Octave`. Currently, running the 
+can run the model using `Matlab` or `Octave`. Currently, running the
 exceutable file on CRIB is not supported because MATLAB Runtime can not be
 installed there. See [Install PyStemmusScope](#install-pystemmusscope).
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ Run the commands below in a terminal (On Windows, use `python` instead of
 `python3`):
 
 ```sh
-# will be replaced by `pip install pystemmusscope`
-python3 -m pip install git+https://github.com/EcoExtreML/STEMMUS_SCOPE_Processing.git@main
+python3 -m pip install pystemmusscope
 ```
 
 or
@@ -84,7 +83,7 @@ or
 Open a jupyter notebook and run the code below in a cell:
 
 ```python
-!pip install git+https://github.com/EcoExtreML/STEMMUS_SCOPE_Processing.git@main
+!pip install pystemmusscope
 ```
 
 ### Install jupyterlab

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = "Sarah Alidoost"
 # built documents.
 #
 # The short X.Y version.
-version = "0.1.0"
+version = "0.1.1"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ url = https://github.com/EcoExtreML/stemmus_scope_processing
 version = 0.1.1
 
 [options]
-python_requires = >=3.7,<=3.9
+python_requires = >=3.7,<3.10
 zip_safe = False
 include_package_data = True
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ name = PyStemmusScope
 project_urls =
     Bug Tracker = https://github.com/EcoExtreML/stemmus_scope_processing/issues
 url = https://github.com/EcoExtreML/stemmus_scope_processing
-version = 0.1.0
+version = 0.1.1
 
 [options]
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,9 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Natural Language :: English
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 description = python modules for running the STEMMUS-SCOPE model
 keywords =
     STEMMUS-SCOPE
@@ -28,7 +28,7 @@ url = https://github.com/EcoExtreML/stemmus_scope_processing
 version = 0.1.1
 
 [options]
-python_requires = >=3.7,<3.10
+python_requires = >=3.8,<3.11
 zip_safe = False
 include_package_data = True
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ url = https://github.com/EcoExtreML/stemmus_scope_processing
 version = 0.1.1
 
 [options]
+python_requires = >=3.7,<=3.9
 zip_safe = False
 include_package_data = True
 packages = find:


### PR DESCRIPTION
This PR adds the pypi version badge to the README.md.
The version has been bumped to 0.1.1, this will allow us to properly test the Action that pushes the new releases to pypi.

 - Also fixes the linter, which complains due to a change in `pyroma` (setup.cfg missing "python_requires" in`[options]`).
 - Updated the python versions in setup.cfg

Closes #52 