### PR TITLE
Fix version syntax in the environment file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - python<3.11,>=3.8
+  - python>=3.8,<3.11
   - jupyterlab # needed to run notebooks
   - pip:
       - pystemmusscope

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - python>=3.8, python<3.11
+  - python<3.11,>=3.8
   - jupyterlab # needed to run notebooks
   - pip:
-      - git+https://github.com/EcoExtreML/STEMMUS_SCOPE_Processing.git@main # will be replaced by `pip install pystemmusscope`
+      - pystemmusscope


### PR DESCRIPTION
The sonarcloud check failed due to `WARNING: prospector 1.8.1 does not provide the extra 'with_pyroma'` which is a [bug](https://github.com/PyCQA/prospector/issues/545).