### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.3.0
 
 [bumpversion:file:PyStemmusScope/__init__.py]
 search = __version__ = "{current_version}"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,7 +20,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-1966-8460"
 date-released: 2022-11-24
 doi: <insert your DOI here>
-version: "0.2.1"
+version: "0.3.0"
 repository-code: "https://github.com/EcoExtreML/stemmus_scope_processing"
 keywords:
   - STEMMUS SCOPE Processing

--- a/PyStemmusScope/__init__.py
+++ b/PyStemmusScope/__init__.py
@@ -9,4 +9,4 @@ __all__ = ["StemmusScope"]
 
 __author__ = "Sarah Alidoost"
 __email__ = "f.alidoost@esciencecenter.nl"
-__version__ = "0.2.1"
+__version__ = "0.3.0"


### PR DESCRIPTION
This correctly sets the current version to 0.3.0.

The pypi distribution has been updated manually.